### PR TITLE
Handle camera disconnect and reconnect.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
 
     - uses: pguyot/arm-runner-action@v2
       with:
-        base_image: https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2023-12-11/2023-12-11-raspios-bookworm-arm64-lite.img.xz
+        base_image: https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2024-03-15/2024-03-15-raspios-bookworm-arm64-lite.img.xz
         cpu: cortex-a7
         image_additional_mb: 1500
         bind_mount_repository: true

--- a/include/camera_grabber.h
+++ b/include/camera_grabber.h
@@ -55,7 +55,7 @@ class CameraGrabber {
 
     // Note: these 3 functions must be protected by mutual exclusion.
     // Failure to do so will result in UB.
-    void startAndQueue();
+    bool startAndQueue();
     void stop();
     void requeueRequest(libcamera::Request *request);
 

--- a/include/camera_runner.h
+++ b/include/camera_runner.h
@@ -64,7 +64,7 @@ class CameraRunner {
 
     // Note: start and stop are not reenterant. Starting and stopping a camera
     // repeatedly should work, but has not been thoroughly tested.
-    void start();
+    bool start();
     void stop();
 
     // Note: this is public but is a footgun. Destructing this class while a

--- a/src/camera_grabber.cpp
+++ b/src/camera_grabber.cpp
@@ -206,7 +206,7 @@ void CameraGrabber::setControls(libcamera::Request *request) {
     }
 }
 
-boolean CameraGrabber::startAndQueue() {
+bool CameraGrabber::startAndQueue() {
     running = true;
     if (m_camera->start()) {
         return false;// failed to start camera

--- a/src/camera_grabber.cpp
+++ b/src/camera_grabber.cpp
@@ -206,17 +206,17 @@ void CameraGrabber::setControls(libcamera::Request *request) {
     }
 }
 
-void CameraGrabber::startAndQueue() {
+boolean CameraGrabber::startAndQueue() {
     running = true;
     if (m_camera->start()) {
-        throw std::runtime_error("failed to start camera");
+        return false;// failed to start camera
     }
 
     // TODO: HANDLE THIS BETTER
     for (auto &request : m_requests) {
         setControls(request.get());
         if (m_camera->queueRequest(request.get()) < 0) {
-            throw std::runtime_error("failed to queue request");
+            return false; // failed to queue request
         }
     }
 }

--- a/src/camera_grabber.cpp
+++ b/src/camera_grabber.cpp
@@ -219,6 +219,7 @@ bool CameraGrabber::startAndQueue() {
             return false; // failed to queue request
         }
     }
+    return true;
 }
 
 void CameraGrabber::stop() {

--- a/src/camera_runner.cpp
+++ b/src/camera_runner.cpp
@@ -75,7 +75,7 @@ void CameraRunner::setCopyOptions(bool copyIn, bool copyOut) {
     m_copyOutput = copyOut;
 }
 
-void CameraRunner::start() {
+boolean CameraRunner::start() {
     unsigned int stride = grabber.streamConfiguration().stride;
 
     latch start_frame_grabber{2};
@@ -242,7 +242,7 @@ void CameraRunner::start() {
 
     {
         std::lock_guard<std::mutex> lock{camera_stop_mutex};
-        grabber.startAndQueue();
+        return grabber.startAndQueue();
     }
 }
 

--- a/src/camera_runner.cpp
+++ b/src/camera_runner.cpp
@@ -75,7 +75,7 @@ void CameraRunner::setCopyOptions(bool copyIn, bool copyOut) {
     m_copyOutput = copyOut;
 }
 
-boolean CameraRunner::start() {
+bool CameraRunner::start() {
     unsigned int stride = grabber.streamConfiguration().stride;
 
     latch start_frame_grabber{2};

--- a/src/libcamera_jni.cpp
+++ b/src/libcamera_jni.cpp
@@ -159,8 +159,8 @@ Java_org_photonvision_raspi_LibCameraJNI_startCamera
 {
     CameraRunner *runner = reinterpret_cast<CameraRunner *>(runner_);
 
-    runner->start();
-    return true;
+    
+    return runner->start();
 }
 
 /*


### PR DESCRIPTION
LibCameraJNI.startCamera() now truly returns whether starting the camera was successful or not. Tested on rpi 5 unplugged camera (pi cam v1) waited over 3 seconds for it to try to restart the camera, then plugged the camera back in. Logs properly showed "[ERROR] Couldn't start a zero copy Pi Camera while switching video modes".