### PR TITLE
FIxups to not request unrealistic framerates

### DIFF
--- a/src/camera_grabber.cpp
+++ b/src/camera_grabber.cpp
@@ -178,26 +178,20 @@ void CameraGrabber::setControls(libcamera::Request *request) {
         } else {
             controls_.set(controls::AeExposureMode, controls::ExposureShort);
         }
-
-        // 1/fps=seconds
-        // seconds * 1e6 = uS
-        constexpr const int MIN_FRAME_TIME = 1e6 / 250;
-        constexpr const int MAX_FRAME_TIME = 1e6 / 15;
-        controls_.set(libcamera::controls::FrameDurationLimits,
-                      libcamera::Span<const int64_t, 2>{
-                          {MIN_FRAME_TIME, MAX_FRAME_TIME}});
     } else {
         controls_.set(controls::AeEnable,
                       false); // Auto exposure disabled
         controls_.set(controls::ExposureTime,
                       m_settings.exposureTimeUs); // in microseconds
-        controls_.set(
-            libcamera::controls::FrameDurationLimits,
-            libcamera::Span<const int64_t, 2>{
-                {m_settings.exposureTimeUs,
-                 m_settings.exposureTimeUs}}); // Set default to zero, we have
-                                               // specified the exposure time
     }
+
+    // 1/fps=seconds
+    // seconds * 1e6 = uS
+    constexpr const int MIN_FRAME_TIME = 1e6 / 120;
+    constexpr const int MAX_FRAME_TIME = 1e6 / 1;
+    controls_.set(libcamera::controls::FrameDurationLimits,
+                    libcamera::Span<const int64_t, 2>{
+                        {MIN_FRAME_TIME, MAX_FRAME_TIME}});
 
     controls_.set(controls::ExposureValue, 0);
 

--- a/src/camera_model.cpp
+++ b/src/camera_model.cpp
@@ -23,7 +23,6 @@
 static const CameraModel grayScaleCameras[] = {OV9281};
 
 CameraModel stringToModel(const std::string &model) {
-    std::printf("Checking model: %s\n", model.c_str());
     const char *famname = model.c_str();
     if (!strcmp(famname, "ov5647"))
         return OV5647;


### PR DESCRIPTION
Tested on an ov9281 on a pi3 - seems to work for full range of resolutions and exposure settings.