### PR TITLE
feat(driver): expose per-frame ExposureTime via JNI

### DIFF
--- a/include/camera_runner.h
+++ b/include/camera_runner.h
@@ -40,6 +40,10 @@ struct MatPair {
     int64_t captureTimestamp;    // In libcamera time units, hopefully uS? TODO
                                  // actually implement
     int32_t frameProcessingType; // enum value of shader run on the image
+    // Per-frame exposure integration time in microseconds, as reported by
+    // libcamera::controls::ExposureTime. 0 means the metadata was not
+    // available for this frame; consumers should leave timestamps uncorrected.
+    int32_t exposureTimeUs;
 
     MatPair() = default;
     explicit MatPair(int width, int height)
@@ -79,6 +83,7 @@ class CameraRunner {
         int fd;
         ProcessType type;
         uint64_t captureTimestamp;
+        int32_t exposureTimeUs;
     };
 
     std::thread m_threshold;

--- a/include/libcamera_jni.hpp
+++ b/include/libcamera_jni.hpp
@@ -125,6 +125,10 @@ JNIEXPORT jlong JNICALL
 Java_org_photonvision_raspi_LibCameraJNI_getFrameCaptureTime(JNIEnv *, jclass,
                                                              jlong);
 
+JNIEXPORT jlong JNICALL
+Java_org_photonvision_raspi_LibCameraJNI_getFrameExposureTimeUs(JNIEnv *,
+                                                                jclass, jlong);
+
 /*
  * Class:     org_photonvision_raspi_LibCameraJNI
  * Method:    grabFrame

--- a/src/camera_runner.cpp
+++ b/src/camera_runner.cpp
@@ -132,7 +132,15 @@ bool CameraRunner::start() {
                         .get(libcamera::controls::SensorTimestamp)
                         .value_or(0));
 
-                gpu_queue.push({out, type, sensorTimestamp});
+                // libcamera reports ExposureTime in microseconds. value_or(0)
+                // signals "metadata not available" to the Java consumer, which
+                // then leaves the published timestamp uncorrected.
+                int32_t exposureTimeUs = static_cast<int32_t>(
+                    request->metadata()
+                        .get(libcamera::controls::ExposureTime)
+                        .value_or(0));
+
+                gpu_queue.push({out, type, sensorTimestamp, exposureTimeUs});
             }
 
             std::chrono::duration<double, std::milli> elapsedMillis =
@@ -181,6 +189,7 @@ bool CameraRunner::start() {
             // Save the current shader idx
             mat_pair.frameProcessingType = static_cast<int32_t>(data.type);
             mat_pair.captureTimestamp = data.captureTimestamp;
+            mat_pair.exposureTimeUs = data.exposureTimeUs;
 
             uint8_t *processed_out_buf = mat_pair.processed.data;
             uint8_t *color_out_buf = mat_pair.color.data;
@@ -262,7 +271,7 @@ void CameraRunner::stop() {
     threshold.join();
 
     // push sentinel value to stop display thread
-    gpu_queue.push({-1, ProcessType::None, 0});
+    gpu_queue.push({-1, ProcessType::None, 0, 0});
     display.join();
 
     std::printf("stopped all\n");

--- a/src/camera_runner.cpp
+++ b/src/camera_runner.cpp
@@ -132,9 +132,7 @@ bool CameraRunner::start() {
                         .get(libcamera::controls::SensorTimestamp)
                         .value_or(0));
 
-                // libcamera reports ExposureTime in microseconds. value_or(0)
-                // signals "metadata not available" to the Java consumer, which
-                // then leaves the published timestamp uncorrected.
+                // https://libcamera.org/api-html/namespacelibcamera_1_1controls.html#a4e1ca45653b62cd969d4d67a741076eb
                 int32_t exposureTimeUs = static_cast<int32_t>(
                     request->metadata()
                         .get(libcamera::controls::ExposureTime)

--- a/src/libcamera_jni.cpp
+++ b/src/libcamera_jni.cpp
@@ -441,9 +441,6 @@ Java_org_photonvision_raspi_LibCameraJNI_getFrameExposureTimeUs
         return 0;
     }
 
-    // 0 means libcamera did not populate ExposureTime metadata for this
-    // frame. Consumers should treat 0 as "unknown" and not attempt the
-    // SOE -> mid-exposure timestamp correction.
     return static_cast<jlong>(pair->exposureTimeUs);
 }
 

--- a/src/libcamera_jni.cpp
+++ b/src/libcamera_jni.cpp
@@ -429,6 +429,26 @@ Java_org_photonvision_raspi_LibCameraJNI_getFrameCaptureTime
 
 /*
  * Class:     org_photonvision_raspi_LibCameraJNI
+ * Method:    getFrameExposureTimeUs
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL
+Java_org_photonvision_raspi_LibCameraJNI_getFrameExposureTimeUs
+  (JNIEnv *, jclass, jlong pair_)
+{
+    MatPair *pair = reinterpret_cast<MatPair *>(pair_);
+    if (!pair) {
+        return 0;
+    }
+
+    // 0 means libcamera did not populate ExposureTime metadata for this
+    // frame. Consumers should treat 0 as "unknown" and not attempt the
+    // SOE -> mid-exposure timestamp correction.
+    return static_cast<jlong>(pair->exposureTimeUs);
+}
+
+/*
+ * Class:     org_photonvision_raspi_LibCameraJNI
  * Method:    releasePair
  * Signature: (J)Z
  */

--- a/src/main/java/org/photonvision/raspi/LibCameraJNI.java
+++ b/src/main/java/org/photonvision/raspi/LibCameraJNI.java
@@ -127,6 +127,14 @@ public class LibCameraJNI {
     public static native long getFrameCaptureTime(long p_ptr);
 
     /**
+     * Get the integration time (exposure window length) for this frame, as reported by libcamera's
+     * ExposureTime control. Units are microseconds. Returns 0 when libcamera did not populate the
+     * metadata for this frame; consumers should treat 0 as "unknown" and leave timestamps
+     * uncorrected.
+     */
+    public static native long getFrameExposureTimeUs(long p_ptr);
+
+    /**
      * Get the current time, in the same timebase as libcamera gives the frame capture time. Units are
      * nanoseconds.
      */


### PR DESCRIPTION
## Why

PhotonVision's libcamera path currently publishes the start-of-exposure timestamp from `libcamera::controls::SensorTimestamp` as the "image capture time." The scene a detector integrates over actually spans `[SOE, SOE+exposure]`, so the closest single-instant approximation is the midpoint of that window. Surfacing per-frame `ExposureTime` from libcamera is the prerequisite for the consumer-side mid-exposure correction in PhotonVision/photonvision (PR linked once opened).

## What

- Read `libcamera::controls::ExposureTime` alongside the existing `SensorTimestamp` in `camera_runner.cpp` and propagate it through `gpu_queue` → `MatPair`.
- New JNI entry `Java_org_photonvision_raspi_LibCameraJNI_getFrameExposureTimeUs` returns the value in microseconds, matching the existing uS-based exposure setter in this repo.
- `value_or(0)` from libcamera + `MatPair` zero-init means callers get `0` when the metadata wasn't populated for the frame, which the consumer treats as "unknown" and leaves the timestamp uncorrected.

## Verification

- `./gradlew compileJava` and `./gradlew publishToMavenLocal` succeed locally.
- The cmake build (and the actual Pi-side validation) is exercised by the existing arm-runner CI job.
- Consumer PR builds green against the locally-published patched jar.

## Scope notes

- Single-purpose change. No refactors of unrelated code in the runner.
- USB / V4L path is intentionally untouched: that path has separate caveats around proprietary exposure scales (some Arducam V4L drivers) and unreliable per-frame metadata under auto-exposure. Out of scope here.