### PR TITLE
Don't crash if libcamera fails to load

### DIFF
--- a/include/libcamera_jni.hpp
+++ b/include/libcamera_jni.hpp
@@ -44,11 +44,11 @@ Java_org_photonvision_raspi_LibCameraJNI_isLibraryWorking(JNIEnv *, jclass);
 
 /*
  * Class:     test
- * Method:    getCameraNames
+ * Method:    getCameraNamesRaw
  * Signature: ()[Ljava/lang/String;
  */
 JNIEXPORT jobjectArray JNICALL
-Java_org_photonvision_raspi_LibCameraJNI_getCameraNames(JNIEnv *, jclass);
+Java_org_photonvision_raspi_LibCameraJNI_getCameraNamesRaw(JNIEnv *, jclass);
 
 /*
  * Class:     org_photonvision_raspi_LibCameraJNI

--- a/src/libcamera_jni.cpp
+++ b/src/libcamera_jni.cpp
@@ -61,11 +61,11 @@ Java_org_photonvision_raspi_LibCameraJNI_isLibraryWorking(JNIEnv *, jclass) {
 
 /*
  * Class:     org_photonvision_raspi_LibCameraJNI
- * Method:    getCameraNames
+ * Method:    getCameraNamesRaw
  * Signature: ()[Ljava/lang/Object;
  */
 JNIEXPORT jobjectArray JNICALL
-Java_org_photonvision_raspi_LibCameraJNI_getCameraNames
+Java_org_photonvision_raspi_LibCameraJNI_getCameraNamesRaw
   (JNIEnv *env, jclass)
 {
     std::vector<std::shared_ptr<libcamera::Camera>> cameras = GetAllCameraIDs();

--- a/src/main/java/org/photonvision/raspi/LibCameraJNI.java
+++ b/src/main/java/org/photonvision/raspi/LibCameraJNI.java
@@ -184,5 +184,15 @@ public class LibCameraJNI {
     public static native boolean releasePair(long p_ptr);
 
     /** Get an array containing the names/ids/paths of all connected CSI cameras from libcamera. @return All connected CSI cameras' paths */
-    public static native String[] getCameraNames();
+    public static String[] getCameraNames() {
+        try {
+            return getCameraNamesRaw();
+        } catch (UnsatisfiedLinkError e) {
+            e.printStackTrace();
+            return new String[0];
+        }
+    }
+
+    /** Get an array containing the names/ids/paths of all connected CSI cameras from libcamera. @return All connected CSI cameras' paths */
+    public static native String[] getCameraNamesRaw();
 }

--- a/src/main/java/org/photonvision/raspi/LibCameraJNI.java
+++ b/src/main/java/org/photonvision/raspi/LibCameraJNI.java
@@ -188,7 +188,6 @@ public class LibCameraJNI {
         try {
             return getCameraNamesRaw();
         } catch (UnsatisfiedLinkError e) {
-            e.printStackTrace();
             return new String[0];
         }
     }

--- a/src/main/java/org/photonvision/raspi/LibCameraJNI.java
+++ b/src/main/java/org/photonvision/raspi/LibCameraJNI.java
@@ -52,13 +52,23 @@ public class LibCameraJNI {
     }
 
     public static SensorModel getSensorModel(long r_ptr) {
-        int model = getSensorModelRaw(r_ptr);
-        return SensorModel.values()[model];
+        try {
+            int model = getSensorModelRaw(r_ptr);
+            return SensorModel.values()[model];
+        } catch (UnsatisfiedLinkError e) {
+            e.printStackTrace();
+            return SensorModel.Disconnected;
+        }
     }
 
     public static SensorModel getSensorModel(String name) {
-        int model = getSensorModelRaw(name);
-        return SensorModel.values()[model];
+        try {
+            int model = getSensorModelRaw(name);
+            return SensorModel.values()[model];
+        } catch (UnsatisfiedLinkError e) {
+            e.printStackTrace();
+            return SensorModel.Disconnected;
+        }
     }
 
     public static boolean isSupported() {


### PR DESCRIPTION
Currently, if libcamera fails to load, `getSensorModel` and `getCameraNames` throw exceptions. This hides these exceptions from consumers and simply returns `SensorModel.Disconnected` or an empty list to indicate that connection with the camera(s) could not be established.